### PR TITLE
Fixes issue with URLs that already end in a '/' character

### DIFF
--- a/addon/utils/build-url.js
+++ b/addon/utils/build-url.js
@@ -6,5 +6,10 @@ export default function buildOperationUrl(record, opPath, requestType, intance=t
   let adapter = record.store.adapterFor(modelName);
   let path = opPath;
   let baseUrl = adapter.buildURL(modelName, intance ? record.get('id') : null, requestType);
-  return `${baseUrl}/${path}`;
+  
+  if (baseUrl.charAt(baseUrl.length-1) === '/') {
+    return `${baseUrl}${path}`;
+  } else {
+    return `${baseUrl}/${path}`;
+  }
 }


### PR DESCRIPTION
I'm having an issue where ember-api-actions makes a call to:

http://localhost:4200/ember/change-set/change-set/2//validate

Which gets redirected to:

http://192.168.194.201/ember/change-set/change-set/2/validate/

And results in a cross site error..

Basically my '--proxy' web server (nginx) see's the double '/' and redirects the request - but uses its own hostname rather than 'localhost:4200'